### PR TITLE
Allow empty <verbatim></verbatim> tag

### DIFF
--- a/lib/Text/Amuse/Output.pm
+++ b/lib/Text/Amuse/Output.pm
@@ -397,7 +397,7 @@ sub manage_regular {
     };
 
 
-    $string =~ s/<verbatim>(.+?)<\/verbatim>/$save_verb->($1)/gsxe;
+    $string =~ s/<verbatim>(.*?)<\/verbatim>/$save_verb->($1)/gsxe;
 
     my $anchors = '';
     if ($opts{anchors}) {

--- a/t/testfiles/verb.exp.html
+++ b/t/testfiles/verb.exp.html
@@ -4,6 +4,10 @@
 </p>
 
 <p>
+ Empty verbatim.
+</p>
+
+<p>
 [1] Hello there.
 </p>
 

--- a/t/testfiles/verb.exp.ltx
+++ b/t/testfiles/verb.exp.ltx
@@ -2,6 +2,9 @@
 ** Hello there
 
 
+ Empty verbatim.
+
+
 [1] Hello there.
 
 
@@ -13,7 +16,7 @@ Test *M \textbackslash{}\{\#!\_<"> e*\forcelinebreak
 Test **M \textbackslash{}\{\#!\_<"> e**\forcelinebreak 
 Test ***M \textbackslash{}\{\#!\_<"> e***\forcelinebreak 
 Test =M \textbackslash{}\{\#!\_<"> e=\forcelinebreak 
-Test <verbatim> </verbatim>
+Test <verbatim> <\Slash{}verbatim>
 
 
 Test <br> Test <br />\forcelinebreak 

--- a/t/testfiles/verb.muse
+++ b/t/testfiles/verb.muse
@@ -3,6 +3,8 @@
 
 <verbatim>** Hello there</verbatim>
 
+<verbatim></verbatim> Empty verbatim.
+
 <verbatim>[1]</verbatim> Hello there.
 
 Footnote [1] and not a footnote <verbatim>[1]</verbatim>


### PR DESCRIPTION
Behavior is made consistent with Emacs Muse.