### PR TITLE
Make the set of directive characters the same as in Emacs Muse

### DIFF
--- a/lib/Text/Amuse/Document.pm
+++ b/lib/Text/Amuse/Document.pm
@@ -177,7 +177,7 @@ sub _split_body_and_directives {
             # reset the directives on blank lines
             if ($line =~ m/^\s*$/s) {
                 $lastdirective = undef;
-            } elsif ($line =~ m/^\#([A-Za-z0-9]+)(\s+(.+))?$/s) {
+            } elsif ($line =~ m/^\#([A-Za-z-]+)(\s+(.+))?$/s) {
                 my $dir = $1;
                 if ($2) {
                     $directives{$dir} = $3;


### PR DESCRIPTION
Directives can't contain numbers, but can contain "-" (which is not documented).
See https://github.com/alexott/muse/blob/0bb5d3fa57bfc876bacec732a0c1d8f796942403/lisp/muse-publish.el#L108