### PR TITLE
Don't allow note references to start with 0

### DIFF
--- a/lib/Text/Amuse/Document.pm
+++ b/lib/Text/Amuse/Document.pm
@@ -420,7 +420,7 @@ with a numerical argument or even with a string like [123]
 sub get_footnote {
     my ($self, $arg) = @_;
     return undef unless $arg;
-    if ($arg =~ m/(\{[0-9]+\}|\[[0-9]+\])/) {
+    if ($arg =~ m/(\{[1-9][0-9]*\}|\[[1-9][0-9]*\])/) {
         $arg = $1;
     }
     else {
@@ -537,7 +537,7 @@ sub _parse_string {
         $element{type} = "comment";
         return %element;
     }
-    if ($l =~ m/^((\[([0-9]+)\])\x{20}+)(.+)$/s) {
+    if ($l =~ m/^((\[([1-9][0-9]*)\])\x{20}+)(.+)$/s) {
         $element{type} = "footnote";
         $element{removed} = $1;
         $element{footnote_symbol} = $2;
@@ -546,7 +546,7 @@ sub _parse_string {
         $element{string} = $4;
         return %element;
     }
-    if ($l =~ m/^((\{([0-9]+)\})\x{20}+)(.+)$/s) {
+    if ($l =~ m/^((\{([1-9][0-9]*)\})\x{20}+)(.+)$/s) {
         $element{type} = "secondary_footnote";
         $element{removed} = $1;
         $element{footnote_symbol} = $2;

--- a/lib/Text/Amuse/Output.pm
+++ b/lib/Text/Amuse/Output.pm
@@ -428,8 +428,8 @@ sub inline_elements {
                             (?<link>         \[\[[^\[].*?\]\])      |
                             (?<open_verb>    \<verbatim\>)     |
                             (?<close_verb>   \<\/verbatim\>)  |
-                            (?<pri_footnote> \s*\[[0-9]+\]) |
-                            (?<sec_footnote> \s*\{[0-9]+\}) |
+                            (?<pri_footnote> \s*\[[1-9][0-9]*\]) |
+                            (?<sec_footnote> \s*\{[1-9][0-9]*\}) |
                             (?<tag> \<
                                 (?<close>\/?)
                                 (?<tag_name> strong | em |  code | strike | del | sup |  sub )
@@ -813,9 +813,9 @@ sub manage_header {
         }
     };
     $body_with_no_footnotes =~ s/(
-                                     \{ [0-9]+ \}
+                                     \{ [1-9][0-9]* \}
                                  |
-                                     \[ [0-9]+ \]
+                                     \[ [1-9][0-9]* \]
                                  )
                                 /$catch_fn->($1)/gxe;
     undef $catch_fn;

--- a/t/footnotes.t
+++ b/t/footnotes.t
@@ -6,7 +6,7 @@ use Text::Amuse::Functions qw/muse_to_html muse_to_tex/;
 use File::Spec::Functions;
 use Data::Dumper;
 
-plan tests => 24;
+plan tests => 30;
 
 my $fn = Text::Amuse::Document->new(file => catfile(t => testfiles => 'footnotes.muse'));
 
@@ -83,3 +83,21 @@ MUSE
     # diag $html;
 }
 
+{
+    my $muse =<<'MUSE';
+#title test
+
+Zero [0]
+
+[0] zero
+MUSE
+
+    my $html = muse_to_html($muse);
+    my $ltx  = muse_to_tex($muse);
+    like $html, qr{0.*0}s, "Found zero in HTML";
+    unlike $html, qr{footnote}, "Not an html footnote";
+    like $ltx, qr{0.*0}s, "Found zero in TeX";
+    unlike $ltx, qr{footnote}, "Not a footnote";
+    is $html, "\n<p>\nZero [0]\n</p>\n\n<p>\n[0] zero\n</p>\n", "html is good";
+    is $ltx, "\nZero [0]\n\n\n[0] zero\n\n", "ltx is good";
+}


### PR DESCRIPTION
Previously it was possible to define footnotes [01] and [1],
which were recognized as different.

The change is consistent with Emacs Muse behavior.