### PR TITLE
Improve unmatched tag warnings

### DIFF
--- a/lib/Text/Amuse/Output.pm
+++ b/lib/Text/Amuse/Output.pm
@@ -699,10 +699,18 @@ sub manage_regular {
     @tracking = ();
     # print Dumper(\@pieces);
 
-    my $warning = 'Found %s tag %s '
-                  . " in <$string> without a matching closing tag. "
-                  . "Leaving it as-is, but it's unlikely you want this. "
-                  . "To suppress this warning, wrap it around <verbatim>\n";
+    chomp (my $chomped_string = $string);
+    my $format_warning = sub($$) {
+        my ($type, $tag) = @_;
+        my $matching = 'closing';
+        if ($type eq 'close' or $type eq 'close_inline') {
+            $matching = 'opening';
+        }
+        return "Found $type tag $tag"
+             . " in <$chomped_string> without a matching $matching tag. "
+             . "Leaving it as-is, but it's unlikely you want this. "
+             . "To suppress this warning, wrap it in <verbatim>\n";
+    };
 
   UNROLL:
     while (@pieces) {
@@ -715,7 +723,7 @@ sub manage_regular {
                 next UNROLL;
             }
             else {
-                warn sprintf($warning, $piece->type, $piece->tag);
+                warn $format_warning->($piece->type, $piece->tag);
                 $piece->type('text');
             }
         }
@@ -726,7 +734,7 @@ sub manage_regular {
                 next UNROLL;
             }
             else {
-                warn sprintf($warning, $piece->type, $piece->tag);
+                warn $format_warning->($piece->type, $piece->tag);
                 $piece->type('text');
             }
         }
@@ -746,7 +754,7 @@ sub manage_regular {
                 push @tagpile, $piece->tag;
             }
             else {
-                warn sprintf($warning, $piece->type, $piece->tag);
+                warn $format_warning->($piece->type, $piece->tag);
                 $piece->type('text');
             }
         }
@@ -763,7 +771,7 @@ sub manage_regular {
                 }
             }
             else {
-                warn sprintf($warning, $piece->type, $piece->tag);
+                warn $format_warning->($piece->type, $piece->tag);
                 $piece->type('text');
             }
         }


### PR DESCRIPTION
First, do not use sprintf, because $string may contain format string specifiers.

For example, if the document contains `<em> -->%2$s<--`, the warning reads
```
Warning: Found open tag em  in <<em> -->em<--
```

Second, chomp the $string before printing it, so > appears on the same line.

Third, print "without a matching *opening* tag" when present tag is opening one.